### PR TITLE
feat(main): implement fallback for --setversion

### DIFF
--- a/src/format_util.rs
+++ b/src/format_util.rs
@@ -1,0 +1,4 @@
+
+pub fn get_short_hash(hash: &str) -> &str {
+    hash.slice_chars(0,8)
+}

--- a/src/git.rs
+++ b/src/git.rs
@@ -24,6 +24,16 @@ pub fn get_latest_tag () -> String {
             .to_string()
 }
 
+pub fn get_last_commit () -> String {
+    Command::new("git")
+            .arg("rev-parse")
+            .arg("HEAD")
+            .spawn()
+            .ok().expect("failed to invoke rev-parse")
+            .stdout.get_mut_ref().read_to_string()
+            .ok().expect("failed to get last commit")
+}
+
 pub fn get_log_entries (config:LogReaderConfig) -> Vec<LogEntry>{
 
     let range = match config.from {

--- a/src/log_writer.rs
+++ b/src/log_writer.rs
@@ -1,6 +1,7 @@
 use std::collections::hashmap::HashMap;
 use std::io::{Writer, IoResult};
 use time;
+use format_util;
 use common::{ LogEntry };
 
 pub struct LogWriter<'a> {
@@ -17,7 +18,7 @@ pub struct LogWriterOptions<'a> {
 impl<'a> LogWriter<'a> {
 
     fn commit_link(&self, hash: &String) -> String {
-        let short_hash = hash.as_slice().slice_chars(0,8);
+        let short_hash = format_util::get_short_hash(hash.as_slice());
         match self.options.repository_link.as_slice() {
             "" => format!("({})", short_hash),
             link => format!("[{}]({}/commit/{})", short_hash, link, hash)
@@ -42,14 +43,7 @@ impl<'a> LogWriter<'a> {
 
         let date = time::now_utc().strftime("%Y-%m-%d");
 
-        if self.options.repository_link.len() > 0 {
-            write!(self.writer, "{} ({})\n\n", version_text, date)
-        } else {
-            write!(self.writer, "<a name=\"{}\"</a>\n{} ({})\n\n",
-                                self.options.version,
-                                version_text,
-                                date)
-        }
+        write!(self.writer, "{} ({})\n\n", version_text, date)
     }
 
     pub fn write_section(&mut self, title: &str, section: &HashMap<String, Vec<LogEntry>>)

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod common;
 mod git;
 mod log_writer;
 mod section_builder;
+mod format_util;
 
 docopt!(Args, "clog
 
@@ -36,7 +37,8 @@ Options:
   --from=<from>           e.g. 12a8546
   --to=<to>               e.g. 8057684
   --from-latest-tag       uses the latest tag as starting point. Ignores other --from parameter",
-  flag_from: Option<String>)
+  flag_from: Option<String>,
+  flag_setversion: Option<String>)
 
 fn main () {
 
@@ -62,7 +64,10 @@ fn main () {
     let mut file = File::open_mode(&Path::new("changelog.md"), Open, Write).ok().unwrap();
     let mut writer = LogWriter::new(&mut file, LogWriterOptions {
         repository_link: args.flag_repository,
-        version: args.flag_setversion,
+        version: match args.flag_setversion {
+          Some(version) => version,
+          _             => format_util::get_short_hash(git::get_last_commit().as_slice()).to_string()
+        },
         subtitle: args.flag_subtitle
     });
 


### PR DESCRIPTION
This commit changes the behaviour so that if
no `--setversion` is specified clog will just
use the short hash of the current revision
as the version number.

Fixes #10

@Ryman do you like to review this first?
