### PR TITLE
refactor: Remove dependency on regex_macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,6 @@ dependencies = [
  "ansi_term 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 1.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clog 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex_macros 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -84,14 +83,6 @@ dependencies = [
 name = "regex-syntax"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "regex_macros"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "rustc-serialize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,6 @@ clap = "~1.4"
 time = "~0.1.32"
 clog = "~0.9.0"
 
-[dependencies.regex_macros]
-version = "~0.1.21"
-optional = true
-
 [dependencies.ansi_term]
 version = "~0.6.3"
 optional = true
@@ -34,7 +30,4 @@ color = ["ansi_term"]
 # For debugging output
 debug = []
 
-# for building with nightly and unstable features
-# until regex_macros compiles with nightly again, this should be commented out
-# unstable = ["regex_macros"]
 unstable = []


### PR DESCRIPTION
It was not used in stable at all, because it only works in nightly.
Now that regex! is almost always slower¹ there's no reason to keep
it in.

¹: https://github.com/rust-lang-nursery/regex/pull/164

(Same change sent to clog-lib as well: https://github.com/clog-tool/clog-lib/pull/13)